### PR TITLE
Fix for Microkit 1.4.0

### DIFF
--- a/libmicrokitco.c
+++ b/libmicrokitco.c
@@ -15,6 +15,13 @@
 #pragma GCC diagnostic error "-Wpedantic"
 #pragma GCC diagnostic push
 
+/* Very simple memzero implementation */
+static void memzero(void *dst, size_t n) {
+    for (int i = 0; i < n; i++) {
+        ((char *)dst)[i] = 0;
+    }
+}
+
 void microkit_cothread_panic(uintptr_t err) {
     volatile char *fault_addr = (volatile char *) err;
     *fault_addr = 0;


### PR DESCRIPTION
Development version of Microkit added memzero in microkit.h for unrelated debugging reasons, this is not necessary and so is not in the mainline one which means libmicrokitco.c needs to have it's own implementaiton of memzero.

Partially closes https://github.com/au-ts/libmicrokitco/issues/11.