### PR TITLE
Fix: allow destroying cothreads from root

### DIFF
--- a/libmicrokitco.c
+++ b/libmicrokitco.c
@@ -366,7 +366,7 @@ void microkit_cothread_destroy(const microkit_cothread_ref_t cothread) {
         microkit_cothread_panic(destroy_already_not_initialised);
     }
 
-    if (co_controller->running == 0) {
+    if (cothread == 0) {
         // cannot destroy root thread
         microkit_cothread_panic(destroy_cannot_destroy_root);
     }


### PR DESCRIPTION
Previously `microkit_cothread_destroy` panicked when called by the root, preventing the root cothread from destroying other cothreads.

Now it checks the target cothread to destroy, and only panics when the target is the root cothread (0).