### PR TITLE
Implement switch_to to allow switching to a specific cothread

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,12 @@ Yield the kernel thread to another cothread and place the caller at the back of 
 
 ---
 
+### `void microkit_cothread_switch_to(const microkit_cothread_ref_t cothread)`
+
+Yield the kernel thread to the specified cothread and place the caller at the back of the scheduling queue.
+
+---
+
 ### `void microkit_cothread_destroy(const microkit_cothread_ref_t cothread)`
 Destroy the given cothread. Internally, the subject cothread's handle is released back into the cothreads pool and such handle is non-scheduleable until it is returned from a `spawn()` call.
 

--- a/libmicrokitco.c
+++ b/libmicrokitco.c
@@ -357,6 +357,24 @@ void microkit_cothread_yield(void) {
     internal_go_next();
 }
 
+void microkit_cothread_switch_to(const microkit_cothread_ref_t cothread) {
+    if (cothread >= LIBMICROKITCO_MAX_COTHREADS || cothread < 0) {
+        microkit_cothread_panic(generic_invalid_handle);
+    }
+
+    // Caller get pushed onto the appropriate scheduling queue.
+    hosted_queue_t *sched_queue = &co_controller->scheduling_queue;
+    const int sched_err = hostedqueue_push(sched_queue, co_controller->scheduling_queue_mem, &co_controller->running);
+    if (sched_err != LIBHOSTEDQUEUE_NOERR) {
+        microkit_cothread_panic(yield_cannot_schedule_caller);
+    }
+
+    co_controller->tcbs[co_controller->running].state = cothread_ready;
+
+    // Yield to the supplied cothread
+    co_switch(co_controller->tcbs[cothread].co_handle);
+}
+
 void microkit_cothread_destroy(const microkit_cothread_ref_t cothread) {
     if (cothread >= LIBMICROKITCO_MAX_COTHREADS || cothread < 0) {
         microkit_cothread_panic(generic_invalid_handle);

--- a/libmicrokitco.h
+++ b/libmicrokitco.h
@@ -119,6 +119,7 @@ microkit_cothread_ref_t microkit_cothread_my_handle(void);
 void *microkit_cothread_my_arg(void);
 
 void microkit_cothread_yield(void);
+void microkit_cothread_switch_to(const microkit_cothread_ref_t cothread);
 
 void microkit_cothread_destroy(const microkit_cothread_ref_t cothread);
 


### PR DESCRIPTION
This PR adds `microkit_cothread_switch_to` to libmicrokitco. This allows the user to specify a cothread that you want to switch to, rather than yielding and allowing the libraries internal scheduler to choose a new co thread.