### PR TITLE
rv64: use 'addi' not 'addiw' to work with handles above 1<<31

### DIFF
--- a/libco/riscv64.c
+++ b/libco/riscv64.c
@@ -99,7 +99,7 @@ section(text)
         // Begin saving callee saved registers of current context
 
         // We first shift the context buffer ptr down 15 words, then saving from there
-        0xf885859b, // addiw a1, a1, -120
+        0xf8858593, // addi a1, a1, -120
 
         0x0015b023, // sd ra, 0(a1)
         0x0025b423, // sd sp, 8(a1)
@@ -120,7 +120,7 @@ section(text)
         0x0615b823, // sd ra, 112(a1)
 
         // Begin loading callee saved registers of the context we are switching to
-        0xf885051b, // addiw a0, a0, -120
+        0xf8850513, // addi a0, a0, -120
 
         0x00053083, // ld ra, 0(a0)
         0x00853103, // ld sp, 8(a0)
@@ -146,12 +146,11 @@ section(text)
 
 // Hard float
 section(text)
-    // This has not been tested due to a lack of hard-float Microkit binary
     const uint32_t co_swap_function[] = {
         // RV64I InsSet
         // Begin saving callee saved registers of current context
 
-        0xf285859b, // addiw a1, a1, -216
+        0xf2858593, // addi a1, a1, -216
 
         0x0015b023, // sd ra, 0(a1)
         0x0025b423, // sd sp, 8(a1)
@@ -184,7 +183,7 @@ section(text)
         // When co_swap is called, `ra` have the PC we need to resume the `from` cothread!
         0x0c15b823, // sd ra, 208(a1)
 
-        0xf285051b, // addiw a0, a0, -216
+        0xf2850513, // addi a0, a0, -216
 
         // Begin loading callee saved registers of the context we are switching to
         0x00053083, // ld ra, 0(a0)


### PR DESCRIPTION
 'addiw' is a RV64I-specific instruction that does a 32-bit
    signed addition (i.e. 32-bit addition and sign extension).
    However, we are computing an offset to a 64-bit pointer
    (XLEN = 64), making 'addiw' break for any addresses higher
    than 2^31.

After merge:

- [x] percolate down to LionsOS
- [x] percolate down to sDDF
